### PR TITLE
Smooth interpolation

### DIFF
--- a/src/StarterPlayer/StarterPlayerScripts/Marching/GridCell.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/Marching/GridCell.lua
@@ -25,7 +25,8 @@ local function renderTriangle(posA, posB, posC)
 end
 
 local function interpolateVerts(v1,  v2) 
-    return Vector3.new(v1.x, v1.y, v1.z):lerp(Vector3.new(v2.x, v2.y, v2.z), 0.5)
+    local t = (ISO_LEVEL - v1.w) / (v2.w - v1.w) 
+    return Vector3.new(v1.x, v1.y, v1.z):Lerp(Vector3.new(v2.x, v2.y, v2.z), t)
 end
 
 local worldModel = Instance.new("Model", workspace)


### PR DESCRIPTION
Before, triangle verts were placed at the midpoint along edges.
This change makes triangle verts smoothly interpolate along edges.

Screenshot from before:
![image](https://user-images.githubusercontent.com/8873303/83110873-3eb71f00-a0b3-11ea-9741-af8ec6688217.png)

Screenshot after:
![image](https://user-images.githubusercontent.com/8873303/83110964-63ab9200-a0b3-11ea-8dc8-f4722a1c86e0.png)